### PR TITLE
Further reduce image sizes

### DIFF
--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -39,7 +39,15 @@
           </div>
         </div>
         <div class="col-6 u-vertically-center u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/d1f2108a-Slide+-+Jaas.svg" alt="" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/d1f2108a-Slide+-+Jaas.svg",
+              alt="",
+              width="534",
+              height="374",
+              hi_def=True,
+            ) | safe
+          }}
         </div>
       </div>
     </div>
@@ -53,7 +61,15 @@
           <a href="{{ url_for('jaasai.experts_spicule') }}" class="p-button--neutral">Managed solutions</a>
         </div>
         <div class="col-6 u-vertically-center u-align--center u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/87827c6f-Slide+-+experts.svg" alt="" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/87827c6f-Slide+-+experts.svg",
+              alt="",
+              width="534",
+              height="374",
+              hi_def=True,
+            ) | safe
+          }}
         </div>
       </div>
     </div>
@@ -66,7 +82,15 @@
           <p><a href="{{ url_for('jaasai.openstack') }}" class="p-button--positive u-no-margin--bottom">OpenStack solutions</a></p>
         </div>
         <div class="col-6 u-vertically-center u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/c8038e7d-Slide+-+openstack.svg" alt="" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/c8038e7d-Slide+-+openstack.svg",
+              alt="",
+              width="534",
+              height="374",
+              hi_def=True,
+            ) | safe
+          }}
         </div>
       </div>
     </div>
@@ -80,7 +104,15 @@
           <p><a href="{{ url_for('jaasai.big_data') }}" class="p-button--positive u-no-margin--bottom">Big data solutions</a></p>
         </div>
         <div class="col-6 u-vertically-center u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/bc700bb6-Slide+-+big+data.svg" alt="" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/bc700bb6-Slide+-+big+data.svg",
+              alt="",
+              width="534",
+              height="374",
+              hi_def=True,
+            ) | safe
+          }}
         </div>
       </div>
     </div>

--- a/templates/shared/search-panel.html
+++ b/templates/shared/search-panel.html
@@ -8,48 +8,137 @@
         <div class="p-search-panel__main">
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}"
             class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}~containers/kubernetes-master/icon.svg" alt=""
-              class="p-search-panel__featured-image" />
+            {{
+              image(
+                url="https://api.jujucharms.com/charmstore/v5/~containers/kubernetes-master/icon.svg",
+                alt="",
+                width="64",
+                height="64",
+                hi_def=True,
+                extra_classes="p-search-panel__featured-image"
+              ) | safe
+            }}
             <p class="p-search-panel__featured-name">kubernetes</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='elasticsearch') }}"
             class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}elasticsearch/icon.svg" alt="" class="p-search-panel__featured-image" />
+            {{
+              image(
+                url="https://api.jujucharms.com/charmstore/v5/elasticsearch/icon.svg",
+                alt="",
+                width="64",
+                height="64",
+                hi_def=True,
+                extra_classes="p-search-panel__featured-image"
+              ) | safe
+            }}
             <p class="p-search-panel__featured-name">elasticsearch</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='kafka') }}" class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}kafka/icon.svg" alt="" class="p-search-panel__featured-image" />
+            {{
+              image(
+                url="https://api.jujucharms.com/charmstore/v5/kafka/icon.svg",
+                alt="",
+                width="64",
+                height="64",
+                hi_def=True,
+                extra_classes="p-search-panel__featured-image"
+              ) | safe
+            }}
             <p class="p-search-panel__featured-name">kafka</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='zookeeper') }}"
             class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}zookeeper/icon.svg" alt="" class="p-search-panel__featured-image" />
+            {{
+              image(
+                url="https://api.jujucharms.com/charmstore/v5/zookeeper/icon.svg",
+                alt="",
+                width="64",
+                height="64",
+                hi_def=True,
+                extra_classes="p-search-panel__featured-image"
+              ) | safe
+            }}
             <p class="p-search-panel__featured-name">zookeeper</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='ceph') }}" class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}ceph/icon.svg" alt="" class="p-search-panel__featured-image" />
+            {{
+              image(
+                url="https://api.jujucharms.com/charmstore/v5/ceph/icon.svg",
+                alt="",
+                width="64",
+                height="64",
+                hi_def=True,
+                extra_classes="p-search-panel__featured-image"
+              ) | safe
+            }}
             <p class="p-search-panel__featured-name">ceph</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='cassandra') }}"
             class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}cassandra/icon.svg" alt="" class="p-search-panel__featured-image" />
+            {{
+              image(
+                url="https://api.jujucharms.com/charmstore/v5/cassandra/icon.svg",
+                alt="",
+                width="64",
+                height="64",
+                hi_def=True,
+                extra_classes="p-search-panel__featured-image"
+              ) | safe
+            }}
             <p class="p-search-panel__featured-name">cassandra</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='percona-cluster') }}"
             class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}percona-cluster/icon.svg" alt="" class="p-search-panel__featured-image" />
+            {{
+              image(
+                url="https://api.jujucharms.com/charmstore/v5/percona-cluster/icon.svg",
+                alt="",
+                width="64",
+                height="64",
+                hi_def=True,
+                extra_classes="p-search-panel__featured-image"
+              ) | safe
+            }}
             <p class="p-search-panel__featured-name">percona-cluster</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='glance') }}" class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}glance/icon.svg" alt="" class="p-search-panel__featured-image" />
+            {{
+              image(
+                url="https://api.jujucharms.com/charmstore/v5/glance/icon.svg",
+                alt="",
+                width="64",
+                height="64",
+                hi_def=True,
+                extra_classes="p-search-panel__featured-image"
+              ) | safe
+            }}
             <p class="p-search-panel__featured-name">glance</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='mariadb') }}" class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}mariadb/icon.svg" alt="" class="p-search-panel__featured-image" />
+            {{
+              image(
+                url="https://api.jujucharms.com/charmstore/v5/mariadb/icon.svg",
+                alt="",
+                width="64",
+                height="64",
+                hi_def=True,
+                extra_classes="p-search-panel__featured-image"
+              ) | safe
+            }}
             <p class="p-search-panel__featured-name">mariadb</p>
           </a>
           <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='spark') }}" class="p-search-panel__featured-link">
-            <img src="{{ external_urls.charmstore }}spark/icon.svg" alt="" class="p-search-panel__featured-image" />
+            {{
+              image(
+                url="https://api.jujucharms.com/charmstore/v5/spark/icon.svg",
+                alt="",
+                width="64",
+                height="64",
+                hi_def=True,
+                extra_classes="p-search-panel__featured-image"
+              ) | safe
+            }}
             <p class="p-search-panel__featured-name">spark</p>
           </a>
         </div>


### PR DESCRIPTION
## Done
Replaced the images with the image-template in the following areas:
- Homepage hero
- Search dropdown panel

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Open https://jaas.ai
- Open the instpector in go to network tab for both
- Select images only
- Refresh both pages and see the difference in size
- You should see **1.36MB** on live and **266KB** on the demo (Yep thats a saving of **80.5%**)
