### PR TITLE
fix minor typo in 'how it works' section

### DIFF
--- a/templates/jaasai/how-it-works.html
+++ b/templates/jaasai/how-it-works.html
@@ -222,7 +222,7 @@
           necessary to deploy, configure, scale, and maintain cloud
           applications easily with Juju. Charms encapsulate a single
           application and all the code and know-how it takes to operate it,
-          such us how to combine and work with other related applications or
+          such as how to combine and work with other related applications or
           how to upgrade it.
         </p>
         <p>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -132,7 +132,6 @@ def create_app(testing=False):
         series_or_version=None,
         version=None,
     ):
-
         charmhub_url = "https://charmhub.io/" + charm_or_bundle_name
         return flask.redirect(charmhub_url, code=301)
 


### PR DESCRIPTION
## Done

 - fix typo in "how it works" section: "such **us**" -> "such as"

## Screenshots

![image](https://user-images.githubusercontent.com/4047767/219448415-10d8cba3-10cc-4448-beb1-79e1b9a50ebf.png)
