### PR TITLE
Fix broken links to Juju documentation

### DIFF
--- a/templates/jaasai/how-it-works.html
+++ b/templates/jaasai/how-it-works.html
@@ -173,7 +173,7 @@
           of the model in the GUI.
         </p>
         <p>
-          <a href="{{ external_urls.docs }}/getting-started" class="p-link--external">
+          <a href="{{ external_urls.docs }}/juju/get-started-with-juju" class="p-link--external">
             Visit the docs to install Juju
           </a>
         </p>
@@ -192,7 +192,7 @@
           easily collaborate with other users.
         </p>
         <p>
-          <a href="{{ external_urls.docs }}/getting-started">
+          <a href="{{ external_urls.docs }}/juju">
             Visit the docs to get started with JAAS&nbsp;&rsaquo;
           </a>
         </p>
@@ -226,7 +226,7 @@
           how to upgrade it.
         </p>
         <p>
-          <a href="{{ external_urls.docs }}/applications-and-charms" class="p-link--external">
+          <a href="{{ external_urls.docs }}/juju/charmed-operator" class="p-link--external">
             Learn more about charms
           </a>
         </p>
@@ -345,7 +345,7 @@
           tools and documentation to help you get started.
         </p>
         <p>
-          <a href="https://juju.is/docs/getting-started-with-charm-development" class="p-link--external">
+          <a href="{{ external_urls.docs }}/sdk/set-up-a-charm-project" class="p-link--external">
             Learn more about writing charms
           </a>
         </p>
@@ -354,7 +354,7 @@
         <h4>Where can I find more detailed information?</h4>
         <p>
           For further information, read our more detailed guidance in the
-          <a class="p-link--external" href="{{ external_urls.docs }}/getting-started" class="p-link--external">documentation</a>. The
+          <a class="p-link--external" href="{{ external_urls.docs }}/juju" class="p-link--external">documentation</a>. The
           <a href="https://www.ubuntu.com/cloud/juju" class="p-link--external">Ubuntu
             website</a> includes an overview of Canonical&rsquo;s cloud
             products, showing how Juju fits in.
@@ -369,7 +369,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <a href="{{ external_urls.docs }}/getting-started" class="p-button--neutral p-link--external">
+      <a href="{{ external_urls.docs }}/juju" class="p-button--neutral p-link--external">
         Visit the docs to install Juju
       </a>
       <a href="/models" class="p-button--positive">


### PR DESCRIPTION

## Done

* Updated FAQ links to Juju documentation

## QA

- Pull code
- Run `dotrun`
- Open http://0.0.0.0:8029
- Verified that each FAQ link leads to a valid documentation page

## Details

Closes #730

