### PR TITLE
fix: update mattermost link to matrix

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -34,7 +34,7 @@
               <a href="https://discourse.charmhub.io/" class="p-navigation__dropdown-item">Discourse forum</a>
             </li>
             <li>
-              <a href="https://chat.charmhub.io" class="p-navigation__dropdown-item">Mattermost chat</a>
+              <a href="https://matrix.to/#/#charmhub:ubuntu.com" class="p-navigation__dropdown-item">Matrix chat</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
## Done
- Update navigation from a Mattermost link to Matrix

## QA
- Visit the demo
- Check the "Community" navigation dropdown has a link to matrix.
