### PR TITLE
feat: add "topics" back to docs navigation

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -53,6 +53,9 @@
             <li>
               <a href="/operator-day" class="p-navigation__dropdown-item">Operator Day</a>
             </li>
+            <li>
+              <a href="https://charmhub.io/topics" class="p-navigation__dropdown-item">Topics</a>
+            </li>
           </ul>
         </li>
         <li class="p-navigation__item">


### PR DESCRIPTION
## Done

- Added "Topics" back to docs menu

## QA

- Visit the demo
- See "Topics" in the docs menu
- Topics should go to https://charmhub.io/topics


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8100
