### PR TITLE
Add Juju middle pages on Jaas.ai

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -25,6 +25,9 @@
           <a class="p-navigation__link" href="https://juju.is">Juju</a>
         </li>
         <li class="p-navigation__item">
+          <a class="p-navigation__link" href="https:/juju.is/why-juju">How Juju Works</a>
+        </li>
+        <li class="p-navigation__item">
           <a class="p-navigation__link" href="https://charmhub.io">Charmhub</a>
         </li>
         <li class="p-navigation__item--dropdown-toggle" id="learn-link">

--- a/templates/header.html
+++ b/templates/header.html
@@ -25,7 +25,7 @@
           <a class="p-navigation__link" href="https://juju.is">Juju</a>
         </li>
         <li class="p-navigation__item">
-          <a class="p-navigation__link" href="https:/juju.is/why-juju">How Juju Works</a>
+          <a class="p-navigation__link" href="https://juju.is/why-juju">How Juju Works</a>
         </li>
         <li class="p-navigation__item">
           <a class="p-navigation__link" href="https://charmhub.io">Charmhub</a>


### PR DESCRIPTION
## Done
- Add Juju middle pages on Jaas.ai

## QA
- Go to https://jaas-ai-752.demos.haus/
- Check if you can access `How Juju Works` from the main navigation

## Issues
Fixes #https://warthogs.atlassian.net/browse/WD-11205

## Screenshots
<img width="1417" alt="Screenshot 2024-05-10 at 2 35 32 PM" src="https://github.com/canonical/jaas.ai/assets/90341644/1c92c131-a0bf-4edc-a759-49e62cd6fcde">
