### PR TITLE
feat: update screenshots to latest dashboard

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -241,9 +241,9 @@
         <div class="tabs-content-wrapper">
           <div class="row" id="view-models-and-controllers-details">
             {{ image(
-                url="https://assets.ubuntu.com/v1/ddb3a5a4-jaas_landing_page_integrations.png",
+                url="https://assets.ubuntu.com/v1/90922406-integrations.png",
                 alt="",
-                height="510",
+                height="669",
                 width="1031",
                 hi_def=True,
                 loading="auto",
@@ -253,9 +253,9 @@
           </div>
           <div class="row u-hide" id="run-actions">
             {{ image(
-              url="https://assets.ubuntu.com/v1/9ebc2a50-jass_landing_page_run_actions.png",
+              url="https://assets.ubuntu.com/v1/e70dab91-run-action.png",
               alt="",
-              height="510",
+              height="669",
               width="1031",
               hi_def=True,
               loading="auto",
@@ -265,9 +265,9 @@
           </div>
           <div class="row u-hide" id="configure-applications">
             {{ image(
-                url="https://assets.ubuntu.com/v1/e5c2fb04-jaas_landing_page_configure_applications.png",
+                url="https://assets.ubuntu.com/v1/1ac0ed08-configure-app.png",
                 alt="",
-                height="510",
+                height="669",
                 width="1031",
                 hi_def=True,
                 loading="auto",
@@ -277,9 +277,9 @@
           </div>
           <div class="row u-hide" id="onboard-controllers-and-manage-access">
             {{ image(
-                url="https://assets.ubuntu.com/v1/28442c33-jaas_landing_page_controllers.png",
+                url="https://assets.ubuntu.com/v1/2f434d5d-jaas-controllers.png",
                 alt="",
-                height="510",
+                height="669",
                 width="1031",
                 hi_def=True,
                 loading="auto",
@@ -289,9 +289,9 @@
           </div>
           <div class="row u-hide" id="run-audits-and-reports">
             {{ image(
-                url="https://assets.ubuntu.com/v1/28e88a31-jaas_landing_page_run_audits.png",
+                url="https://assets.ubuntu.com/v1/8d0f47a6-action-logs.png",
                 alt="",
-                height="510",
+                height="669",
                 width="1031",
                 hi_def=True,
                 loading="auto",
@@ -301,9 +301,9 @@
           </div>
           <div class="row u-hide" id="search-and-filter">
             {{ image(
-                url="https://assets.ubuntu.com/v1/0a0fc6ba-jaas_landing_page_search_and_filter_final.png",
+                url="https://assets.ubuntu.com/v1/f3ff0a1b-searchandfilter.jpg",
                 alt="",
-                height="510",
+                height="669",
                 width="1031",
                 hi_def=True,
                 loading="auto",


### PR DESCRIPTION
## Done

- Update the screenshots to match the latest dashboard.

## QA

- Pull code
- Run `dotrun`
- Open http://0.0.0.0:8029
- Scroll down to the dashboard screenshots.
- Check that they match the new grey dashboard.

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

<img width="1439" alt="Screenshot 2024-05-20 at 12 19 56 PM" src="https://github.com/canonical/jaas.ai/assets/361637/c1ba2cb2-d33f-4736-ac79-f1dbc0f13e2d">

