### PR TITLE
update nav bar docs link

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -44,16 +44,8 @@
             </li>
           </ul>
         </li>
-        <li class="p-navigation__item--dropdown-toggle" id="contribute-link">
-          <a class="p-navigation__link" href="#docs-link-menu" aria-controls="docs-link-menu">Docs</a>
-          <ul class="p-navigation__dropdown" id="docs-link-menu" aria-hidden="true">
-            <li>
-              <a href="/docs/juju" class="p-navigation__dropdown-item">Juju</a>
-            </li>
-            <li>
-              <a href="/docs/sdk" class="p-navigation__dropdown-item">Charm SDK</a>
-            </li>
-          </ul>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/">Docs</a>
         </li>
         <li class="p-navigation__item">
           <a class="p-navigation__link" href="https://ubuntu.com/blog/tag/juju">Blog</a>


### PR DESCRIPTION
## Done

Update "Docs" in nav bar to point to https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/ rather than have a dropdown.

## QA

- Pull code
- Run `dotrun`
- Open http://0.0.0.0:8029
- Ensure "Docs" link in nav bar is as expected.
