### PR TITLE
remove unnecessary nav bar links

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -25,30 +25,10 @@
           <a class="p-navigation__link" href="https://juju.is">Juju</a>
         </li>
         <li class="p-navigation__item">
-          <a class="p-navigation__link" href="https://juju.is/why-juju">How Juju Works</a>
-        </li>
-        <li class="p-navigation__item">
           <a class="p-navigation__link" href="https://charmhub.io">Charmhub</a>
-        </li>
-        <li class="p-navigation__item--dropdown-toggle" id="learn-link">
-          <a class="p-navigation__link" href="#forum-link-menu" aria-controls="forum-link-menu">Community</a>
-          <ul class="p-navigation__dropdown" id="forum-link-menu" aria-hidden="true">
-            <li>
-              <a href="https://discourse.charmhub.io/" class="p-navigation__dropdown-item">Discourse forum</a>
-            </li>
-            <li>
-              <a href="https://matrix.to/#/#charmhub:ubuntu.com" class="p-navigation__dropdown-item">Matrix chat</a>
-            </li>
-            <li>
-              <a href="/operator-day" class="p-navigation__dropdown-item">Operator Day</a>
-            </li>
-          </ul>
         </li>
         <li class="p-navigation__item">
           <a class="p-navigation__link" href="https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/">Docs</a>
-        </li>
-        <li class="p-navigation__item">
-          <a class="p-navigation__link" href="https://ubuntu.com/blog/tag/juju">Blog</a>
         </li>
       </ul>
       <ul class="p-navigation__items p-navigation_login global-nav" role="menu">


### PR DESCRIPTION
## Done

Remove the "How Juju Works", "Community", and "Blog" buttons.

## QA

- Pull code
- Run `dotrun`
- Open http://0.0.0.0:8029
- Check links have been removed from nav bar
