### PR TITLE
Mandatory job title field on jaas.ai contact forms

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -440,15 +440,15 @@
       <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal" data-js="close-modal-control">Close</button>
     </header>
     <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_5332" style="max-width: 560px;">
-      <label for="firstName">First name</label>
+      <label class="is-required" for="firstName">First name</label>
       <input type="text" name="firstName" id="firstName" required>
-      <label for="lastName">Last name</label>
+      <label class="is-required" for="lastName">Last name</label>
       <input type="text" name="lastName" id="lastName" required>
       <label class="is-required" for="title">Job title</label>
       <input type="text" name="title" id="title" required>
-      <label for="Email">Email address:</label>
+      <label class="is-required" for="Email">Email address:</label>
       <input type="email" name="email" id="email" required>
-      <label for="phone">Phone</label>
+      <label class="is-required" for="phone">Phone</label>
       <input type="text" name="phone" id="phone" required>
       <label for="Comments_from_lead__c">Comments</label>
       <textarea name="Comments_from_lead__c" id="Comments_from_lead__c"></textarea>

--- a/templates/index.html
+++ b/templates/index.html
@@ -444,7 +444,7 @@
       <input type="text" name="firstName" id="firstName" required>
       <label for="lastName">Last name</label>
       <input type="text" name="lastName" id="lastName" required>
-      <label for="title">Job title</label>
+      <label class="is-required" for="title">Job title</label>
       <input type="text" name="title" id="title" required>
       <label for="Email">Email address:</label>
       <input type="email" name="email" id="email" required>


### PR DESCRIPTION
## Done

- Company and Job title fields are now mandatory
- drive by: added missing "is-required" class on required input's labels

## QA

- View the site in your web browser at: https://jaas-ai-782.demos.haus/
- Click the green "Contact us" button
- Verify the job title field is mandatory

Bonus points: try to submit the form to make sure it works.


## Issue / Card

Fixes #[WD-19677](https://warthogs.atlassian.net/browse/WD-19677)

[WD-19677]: https://warthogs.atlassian.net/browse/WD-19677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ