### PR TITLE
fix: update JAAS controller screenshot to remove patched UI bug

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -174,7 +174,7 @@
           </div>
           <div class="row u-hide" id="onboard-controllers-and-manage-access">
             {{ image(
-                url="https://assets.ubuntu.com/v1/2f434d5d-jaas-controllers.png",
+                url="https://assets.ubuntu.com/v1/d54720f1-jaas-controllers.png",
                 alt="",
                 height="669",
                 width="1031",


### PR DESCRIPTION
## Done

- update JAAS controller screenshot to have correct percentages

## QA

- Pull code
- Run `dotrun`
- Open http://0.0.0.0:8029
- Scroll to "Enhanced control and visibility for your Juju deployment", and ensure that the "Onboard controllers and manage access" item in the carousel fits in with the other images

## Details

Replaces [previous asset](https://assets.ubuntu.com/v1/2f434d5d-jaas-controllers.png) with bad percentages, with [updated asset](https://assets.ubuntu.com/v1/d54720f1-jaas-controllers.png) which displays correct percentages. This screenshot was produced using a version of Juju Dashboard with the fix from https://github.com/canonical/juju-dashboard/pull/1979.

## Screenshots

(might have to zoom in to see the percentages)

### Before

![image](https://github.com/user-attachments/assets/ef0daf83-0809-4e83-bca1-0df857a27ff5)

### After

![image](https://github.com/user-attachments/assets/db382b64-4da0-4d34-9524-616d9e536029)

