### PR TITLE
docs: update jaas docs link

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -28,7 +28,7 @@
           <a class="p-navigation__link" href="https://charmhub.io">Charmhub</a>
         </li>
         <li class="p-navigation__item">
-          <a class="p-navigation__link" href="https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/">Docs</a>
+          <a class="p-navigation__link" href="https://documentation.ubuntu.com/jaas">Docs</a>
         </li>
       </ul>
       <ul class="p-navigation__items p-navigation_login global-nav" role="menu">


### PR DESCRIPTION
## Done
JAAS docs have just moved to https://documentation.ubuntu.com/jaas . This PR updates the link on jaas.ai.

## QA

- Pull code
- Run `dotrun`
- Open http://0.0.0.0:8029
- [Add additional steps]

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
