### PR TITLE
Bugfix: added acquisition_url for contact form

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -473,7 +473,7 @@
       <input type="hidden" name="utmcontent" id="utmcontent" value="">
       <input type="hidden" name="utm_term" id="utm_term" value="">
       <input type="hidden" name="GCLID__c" id="GCLID__c" value="">
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="acquisition_url" id="acquisition_url" value="{{ request.url }}" />
+      <input type="hidden" name="acquisition_url" id="acquisition_url" value="{{ request.url }}" />
       <input type="hidden" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="">
       <input type="hidden" name="grecaptcharesponse" id="grecaptcharesponse" value="">
       <input type="hidden" name="productContext" id="productContext" value="">

--- a/templates/index.html
+++ b/templates/index.html
@@ -473,6 +473,7 @@
       <input type="hidden" name="utmcontent" id="utmcontent" value="">
       <input type="hidden" name="utm_term" id="utm_term" value="">
       <input type="hidden" name="GCLID__c" id="GCLID__c" value="">
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="acquisition_url" id="acquisition_url" value="{{ request.url }}" />
       <input type="hidden" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="">
       <input type="hidden" name="grecaptcharesponse" id="grecaptcharesponse" value="">
       <input type="hidden" name="productContext" id="productContext" value="">


### PR DESCRIPTION
## Done

- added acquisition_url for contact form
## QA

- Pull code
- Run `dotrun`
- Open http://0.0.0.0:8029
- Visit the [Demo](https://jaas-ai-792.demos.haus/)
- Submit the form and inspect the network payload to confirm it contains right acquisition URL.

